### PR TITLE
Changes orphaCode parameter from integer to string

### DIFF
--- a/specification.yaml
+++ b/specification.yaml
@@ -87,9 +87,7 @@ paths:
           in: query
           required: false
           schema:
-            code:
-              type: integer
-              format: int32
+            type: string
         - name: medAreas
           description: >-
             The medical areas of the desired resource. If this
@@ -238,8 +236,7 @@ components:
           type: string
         orphaCode:
           description: "The orphacode of the disease."
-          type: integer
-            format: int32
+          type: string
         medArea:
           description: >-
             Medical area of the desired resource. If this field is null/not specified, 


### PR DESCRIPTION
This PR changes the type of the orphaCode parameter. 
Although orpha codes are composed of digits, they represent alphanumeric data so I think that string type is more appropriate. 