### PR TITLE
Removes apiId since it seems redundant with apiVersion

### DIFF
--- a/specification.yaml
+++ b/specification.yaml
@@ -208,11 +208,8 @@ components:
     DataResponse:
       type: object
       required:
-        - apiId
+        - apiVersion
       properties:
-        apiId:
-          description: "Identifier of the API, as defined in InfoResponse."
-          type: string
         apiVersion:
           description: Version of the API. If specified, the value must match `apiVersion`
             in InfoResponse.


### PR DESCRIPTION
As per title I just removed the apiId which seems to have the same meaning of version