### PR TITLE
Adds possible values for type in openapi

### DIFF
--- a/versions/v02/specification.yaml
+++ b/versions/v02/specification.yaml
@@ -207,7 +207,11 @@ components:
         type:
           type: string
           description: The type of the resource.
-          example: "Patient registry"
+          example: "PatientRegistryDataset"
+          enum: [
+            "PatientRegistryDataset", 
+            "BiobankDataset"
+          ]
     Organization:
       description: A schema to describe an organisation
       type: object


### PR DESCRIPTION
resource.json schema specifies enum for `type` property. This enum was missing in OpenAPI specification. This PR adds it in order to preserve consistency between the two schemas