### PR TITLE
Changes the `page` name of the Page schema

### DIFF
--- a/versions/v02/specification.yaml
+++ b/versions/v02/specification.yaml
@@ -265,6 +265,6 @@ components:
         size:
           description: Number of resources for every page
           type: integer
-        page:
+        number:
           description: Number of the current page
           type: integer


### PR DESCRIPTION
The Page schema had a property called `page` which specified the number of the current page. This resulted in DataResponse like:
```
{...
   page: {
      ....,
      page: 0
   }
}

which is redundant. This PR changes the property name to number